### PR TITLE
rename highlight_group => highlight_groups

### DIFF
--- a/powerlinex/segment/rbenv.py
+++ b/powerlinex/segment/rbenv.py
@@ -21,7 +21,7 @@ def version(pl, segment_info):
             else:
                 return [{
                     'contents': line.split(" ")[0],
-                    'highlight_group': ['ruby_version', 'virtualenv']
+                    'highlight_groups': ['ruby_version', 'virtualenv']
                 }]
     except OSError as e:
         if e.errno == 2:


### PR DESCRIPTION
The JSON key names for colorscheme have been changed in the issue https://github.com/powerline/powerline/issues/1199 . I apply this with this patch.
